### PR TITLE
Ensure that we are running the newest version of the image

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ uid: 1000
 host_volume: /home/teamspeak/teamspeak3-data
 volume_mode: rw
 container_restart_policy: always
+pull_image: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
   docker_container:
     name: teamspeak3
     image: "aheil/teamspeak3-server"
+    pull: "{{ pull_image }}"
     state: started
     published_ports:
       - "9987:9987/udp"


### PR DESCRIPTION
From https://docs.ansible.com/ansible/latest/modules/docker_container_module.html

> If true, always pull the latest version of an image. Otherwise, will only pull an image when missing.
Note that images are only pulled when specified by name. If the image is specified as a image ID (hash), it cannot be pulled.